### PR TITLE
#18. Fixed puzzles.xml validation.

### DIFF
--- a/src/main/java/com/selfxdsd/todos/DocumentPuzzles.java
+++ b/src/main/java/com/selfxdsd/todos/DocumentPuzzles.java
@@ -73,8 +73,14 @@ public final class DocumentPuzzles implements Puzzles<String> {
     @Override
     public void process(final String input) throws PuzzlesProcessingException {
         try {
-            final Document document = DocumentBuilderFactory
-                .newInstance()
+            final String schemaLanguage =
+                "http://java.sun.com/xml/jaxp/properties/schemaLanguage";
+            final String schema = "http://www.w3.org/2001/XMLSchema";
+            DocumentBuilderFactory factory = DocumentBuilderFactory
+                .newInstance();
+            factory.setNamespaceAware(true);
+            factory.setAttribute(schemaLanguage, schema);
+            final Document document = factory
                 .newDocumentBuilder()
                 .parse(new InputSource(new StringReader(input)));
             SchemaFactory

--- a/src/test/resources/puzzles.xml
+++ b/src/test/resources/puzzles.xml
@@ -1,4 +1,5 @@
 <puzzles xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://pdd-xsd.teamed.io/0.20.5.xsd"
          version="0.20.5"
          date="2020-09-07T16:20:26Z">
     <puzzle>


### PR DESCRIPTION
- `xsi:noNamespaceSchemaLocation` was treated as an xml element against schema, thus making the validation to fail.

Fixes for #18
Close #18