### PR TITLE
#30 use latest commit SHA for issue body

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 	<properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
-        <self.core.version>0.0.33</self.core.version>
-        <self.storage.version>0.0.14</self.storage.version>
+        <self.core.version>0.0.36</self.core.version>
+        <self.storage.version>0.0.15</self.storage.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/com/selfxdsd/todos/DocumentPuzzles.java
+++ b/src/main/java/com/selfxdsd/todos/DocumentPuzzles.java
@@ -100,9 +100,10 @@ public final class DocumentPuzzles implements Puzzles<String> {
             final Element root = document
                 .getDocumentElement();
             final NodeList puzzleTags = root.getElementsByTagName("puzzle");
+            final Commit latest = this.project.repo().commits().latest();
             for (int i = 0; i < puzzleTags.getLength(); i++) {
                 final Node node = puzzleTags.item(i);
-                puzzles.add(new PuzzleElement((Element) node));
+                puzzles.add(new PuzzleElement((Element) node, latest));
             }
         } catch (final SAXException
             | IOException
@@ -148,11 +149,12 @@ public final class DocumentPuzzles implements Puzzles<String> {
         /**
          * Ctor.
          * @param element DOM Element.
+         * @param latest Latest commit from the repo.
          */
-        private PuzzleElement(final Element element){
+        private PuzzleElement(final Element element, final Commit latest){
             this.delegate = new Puzzle.Builder()
                 .setProject(DocumentPuzzles.this.project)
-                .setCommit(DocumentPuzzles.this.commit)
+                .setCommit(latest)
                 .setId(this.textContext(element, "id"))
                 .setTicket(Integer
                     .parseInt(this.textContext(element, "ticket")))

--- a/src/main/java/com/selfxdsd/todos/Puzzle.java
+++ b/src/main/java/com/selfxdsd/todos/Puzzle.java
@@ -131,9 +131,9 @@ public interface Puzzle {
         private Project project;
 
         /**
-         * Commit which triggered the puzzle discovery.
+         * Latest commit in the Repo.
          */
-        private Commit commit;
+        private Commit latest;
 
         /**
          * Unique ID of the puzzle.
@@ -205,7 +205,7 @@ public interface Puzzle {
          * @return Builder.
          */
         public Builder setCommit(final Commit commit) {
-            this.commit = commit;
+            this.latest = commit;
             return this;
         }
 
@@ -426,7 +426,7 @@ public interface Puzzle {
                     final String body;
                     if(Provider.Names.GITHUB.equalsIgnoreCase(provider)) {
                         body = "https://github.com/" + project.repoFullName()
-                            + "/blob/" + commit.shaRef() + "/" + this.getFile()
+                            + "/blob/" + latest.shaRef() + "/" + this.getFile()
                             + "#" + this.getLines() + "\n\n"
                             + "\"" + this.getBody() + "\".";
                     } else {

--- a/src/main/java/com/selfxdsd/todos/PuzzlesComponent.java
+++ b/src/main/java/com/selfxdsd/todos/PuzzlesComponent.java
@@ -144,7 +144,9 @@ public class PuzzlesComponent {
         if(opened.size() > 0) {
             commit.comments().post(
                 "@" + commit.author() + " I've opened the Issues "
-                + opened + " for the newly added to-dos."
+                + opened + " for the newly added to-dos.\n\n"
+                + "The to-dos may have been added in an earlier commit, "
+                + "but I've found them just now."
             );
         }
     }
@@ -182,7 +184,9 @@ public class PuzzlesComponent {
         if(closed.size() > 0) {
             commit.comments().post(
                 "@" + commit.author() + " I've closed the Issues "
-                + closed + " because their to-dos disappeared from the code."
+                + closed + " since their to-dos disappeared from the code.\n\n"
+                + "The to-dos may have been removed in an earlier commit, but "
+                + "I've found it just now."
             );
         }
     }

--- a/src/test/java/com/selfxdsd/todos/DocumentPuzzlesTestCase.java
+++ b/src/test/java/com/selfxdsd/todos/DocumentPuzzlesTestCase.java
@@ -1,7 +1,6 @@
 package com.selfxdsd.todos;
 
-import com.selfxdsd.api.Commit;
-import com.selfxdsd.api.Project;
+import com.selfxdsd.api.*;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -12,6 +11,7 @@ import org.mockito.Mockito;
  * @author criske
  * @version $Id$
  * @since 0.0.1
+ * @checkstyle ExecutableStatementCount (500 lines)
  */
 public final class DocumentPuzzlesTestCase {
 
@@ -21,9 +21,17 @@ public final class DocumentPuzzlesTestCase {
      */
     @Test
     public void canParsePuzzlesFromXml() throws PuzzlesProcessingException {
+        final Commits commits = Mockito.mock(Commits.class);
+        Mockito.when(commits.latest()).thenReturn(Mockito.mock(Commit.class));
+        final Repo repo = Mockito.mock(Repo.class);
+        Mockito.when(repo.commits()).thenReturn(commits);
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.repo()).thenReturn(repo);
+
+
         final Puzzles<String> puzzles = new ResourcesPuzzles(
             new DocumentPuzzles(
-                Mockito.mock(Project.class),
+                project,
                 Mockito.mock(Commit.class)
             )
         );


### PR DESCRIPTION
Fixes #30 

Updated self-core to 0.0.36 and self-storage to 0.0.15;
When reporting a ticket on Github, we have to use the SHA of the latest commit to reference the lines of code;
Better messages for opened/closed tickets.