### PR TITLE
#39 add test for JsonPuzzles.process() when parsing invalid json.

### DIFF
--- a/src/main/java/com/selfxdsd/todos/SshPuzzles.java
+++ b/src/main/java/com/selfxdsd/todos/SshPuzzles.java
@@ -43,8 +43,6 @@ import java.util.stream.Collectors;
  * @author criske
  * @version $Id$
  * @since 0.0.1
- * @todo #7:30min Write unit test for SshPuzzles and unit DocumentPuzzles
- *  for cases when there are invalid documents.
  */
 public final class SshPuzzles implements Puzzles<Project> {
 

--- a/src/main/java/com/selfxdsd/todos/SshPuzzles.java
+++ b/src/main/java/com/selfxdsd/todos/SshPuzzles.java
@@ -43,8 +43,6 @@ import java.util.stream.Collectors;
  * @author criske
  * @version $Id$
  * @since 0.0.1
- * @todo #7:30min Write unit test for SshPuzzles and unit DocumentPuzzles
- *  for cases when there are invalid documents.
  * @todo #12:30min. Handle SshPuzzles errors output with
  *  PuzzlesProcessingException. Right now there is one single String output.
  *  Instead of a String we should have 2 streams one for puzzles and

--- a/src/test/java/com/selfxdsd/todos/JsonPuzzlesTestCase.java
+++ b/src/test/java/com/selfxdsd/todos/JsonPuzzlesTestCase.java
@@ -1,12 +1,9 @@
 package com.selfxdsd.todos;
 
-import com.selfxdsd.api.Commit;
-import com.selfxdsd.api.Commits;
-import com.selfxdsd.api.Project;
-import com.selfxdsd.api.Repo;
+import com.selfxdsd.api.*;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.mockito.Mockito;
 
 /**
@@ -71,4 +68,22 @@ public final class JsonPuzzlesTestCase {
         System.out.println(puzzle.issueBody());
     }
 
+    /**
+     * JsonPuzzles can fail when processing invalid json.
+     *
+     * @throws PuzzlesProcessingException if something went wrong.
+     */
+    @Test(expected = PuzzlesProcessingException.class)
+    public void failToParseInvalidJson() throws PuzzlesProcessingException {
+        Commit commit = Mockito.mock(Commit.class);
+        Comments comments = Mockito.mock(Comments.class);
+        Mockito.when(commit.comments()).thenReturn(comments);
+        Comment comment = Mockito.mock(Comment.class);
+        Mockito.when(comments.post(Mockito.anyString())).thenReturn(comment);
+        new JsonPuzzles(
+            Mockito.mock(Project.class),
+            commit
+        ).process("invalid json");
+        Mockito.verify(comments, Mockito.times(1)).post(Mockito.anyString());
+    }
 }


### PR DESCRIPTION
PR for #39
As [suggested](https://github.com/self-xdsd/self-todos/issues/39#issuecomment-752588913) by @amihaiemil, I added the test only for `JsonPuzzles` as `XmlPuzzles`  is no longer used. 