### PR TITLE
Updated cloneRepoAndPdd.sh to work with gitlab too.

### DIFF
--- a/src/main/java/com/selfxdsd/todos/SshPuzzles.java
+++ b/src/main/java/com/selfxdsd/todos/SshPuzzles.java
@@ -78,8 +78,8 @@ public final class SshPuzzles implements Puzzles<Project> {
     public void process(final Project project)
         throws PuzzlesProcessingException {
         try {
-            final ProjectManager manager = project.projectManager();
             final String id = UUID.randomUUID().toString().replace("-", "");
+            final String repoName = project.repoFullName().split("/")[1];
             this.exec(
                 String.format(
                     new BufferedReader(
@@ -91,12 +91,13 @@ public final class SshPuzzles implements Puzzles<Project> {
                     ).lines().collect(Collectors.joining("\n")),
                     id,
                     id,
-                    project.provider() + "-" + manager.username(),
-                    project.repoFullName()
+                    project.provider(),
+                    project.repoFullName(),
+                    repoName
                 )
             );
             final String puzzles = this.exec(
-                "cd self-todos-tmp-" + id + "/repo"
+                "cd self-todos-tmp-" + id + "/"+ repoName
                 + " && cat ./todos.json");
             this.next.process(puzzles);
         } catch (final IOException | IllegalStateException exception) {

--- a/src/main/resources/cloneRepoAndPdd.sh
+++ b/src/main/resources/cloneRepoAndPdd.sh
@@ -1,5 +1,5 @@
-whoami
-pwd
-mkdir self-todos-tmp-%s && cd self-todos-tmp-%s
-git clone git@%s:%s repo && cd repo
-java -jar /usr/local/bin/todo-finder-cli.jar
+whoami;
+pwd;
+mkdir self-todos-tmp-%s && cd self-todos-tmp-%s;
+git clone git@%s.com:%s;
+cd %s && java -jar /usr/local/bin/todo-finder-cli.jar;


### PR DESCRIPTION
The current script doesn't work for gitlab, this PR will adapt to both providers.

----
#### Webhook Testing (E2E)

Uses a [pipedream workflow](https://pipedream.com/@criske/webhook-relay-p_vQCgOVG/edit) that intercepts the webhook and packs it into a sse message sent to subscribers.
The nice part about this is that you can resend events from pipedream without having to create a new PR to trigger the webhook.

The registered test webhooks have the pipedream endpoint and follow the self webhook callback path convention
`https://ba2eddad3052e18242e582a9f458f702.m.pipedream.net/<<provider>>/<<owner>/<<name>`

`self-pm` front-end will subscribe to this worflow, unpacks the message and will recreate the webhook request (as a POST to github or gitlab `self-pm` processing endpoints). We will need in `self-pom` a controller for that.
```java
@Controller
public final class WebhookProxyController {

    @GetMapping("/webhook-proxy")
    public String webhookProxy(){
        return "webhook-proxy";
    }

}
```
Where "webhook-proxy" is a simple html with js for subscription.
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>Webhook proxy</title>
    <script>
        var eventSource = new EventSource(
            "http://sdk.m.pipedream.net/pipelines/p_vQCgOVG/sse"
        );
        var latest;
        eventSource.addEventListener("webhook", function (e) {
            clearTimeout(latest);
            //prevent replay older events on subscription, unless is the last one.
            latest = setTimeout(function(){
                var data = JSON.parse(e.data);
                var request = new Request(data.url, {method: 'POST', headers: data.headers, body: data.body});
                   fetch(request)
                    .then(r => console.log(r))
                    .catch(e => console.error(e));
            }, 1000);
        });
    </script>
</head>
<body></body>
</html>
```
Now heading up to http://localhost:8181/webhook-proxy will start listen... and any relevant `push` processed by self-pm endpoints will be forwarded to `self-todos` as usual .

